### PR TITLE
Add no-op method removeInspectionPort as NSC does not support port group

### DIFF
--- a/src/main/java/org/osc/controller/nsc/api/NeutronSdnRedirectionApi.java
+++ b/src/main/java/org/osc/controller/nsc/api/NeutronSdnRedirectionApi.java
@@ -214,4 +214,11 @@ public class NeutronSdnRedirectionApi implements SdnRedirectionApi {
     public List<NetworkElement> getNetworkElements(NetworkElement element) throws Exception {
         return null;
     }
+
+    @Override
+    public void removeInspectionPort(InspectionPortElement inspectionPort)
+            throws NetworkPortNotFoundException, Exception {
+        // no-op
+
+    }
 }


### PR DESCRIPTION
Use the same pull request as the osc-core, for adding removeInspectionPort implementation.