### PR TITLE
Enforcing artifact version to match the release version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,11 +30,16 @@
 		<repository>
 			<id>osc-nexus</id>
 			<name>OSC Nexus</name>
-			<snapshots>
-				<enabled>true</enabled>
-			</snapshots>
 			<url>http://ci.opensecuritycontroller.org:8082/nexus/content/repositories/releases</url>
 		</repository>
+        <repository>
+            <id>osc-nexus-snapshot</id>
+            <name>OSC Nexus</name>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+			<url>http://ci.opensecuritycontroller.org:8082/nexus/content/repositories/osc-snapshot</url>
+        </repository>
 	</repositories>
 
 	<dependencies>


### PR DESCRIPTION
This PR is related to opensecuritycontroller/sdn-controller-api#15 . It also make this plugin consume the API artifact version 1.0.0