### PR TITLE
change git clone depth in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,8 @@ language:
     - java
 jdk:
     - oraclejdk8
+git:
+  depth: 99999
 addons:
   apt:
     packages:


### PR DESCRIPTION
see https://docs.travis-ci.com/user/customizing-the-build#Git-Clone-Depth

Because we clone only 50 previous commit our release tags may not get cloned, so cloning the full repository.
Fixes travis build as commits past ~50 will start failing. Will need to do this for all the other repos as well