### PR TITLE
fix unit test

### DIFF
--- a/src/test/java/org/osc/controller/nsc/OSGiIntegrationTest.java
+++ b/src/test/java/org/osc/controller/nsc/OSGiIntegrationTest.java
@@ -16,13 +16,13 @@
  *******************************************************************************/
 package org.osc.controller.nsc;
 
-import static java.util.Arrays.asList;
-import static java.util.Collections.singletonMap;
+import static java.util.Arrays.*;
+import static java.util.Collections.*;
 import static junit.framework.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.ops4j.pax.exam.CoreOptions.*;
-import static org.osc.sdk.controller.FailurePolicyType.NA;
-import static org.osc.sdk.controller.TagEncapsulationType.VLAN;
+import static org.osc.sdk.controller.FailurePolicyType.*;
+import static org.osc.sdk.controller.TagEncapsulationType.*;
 import static org.osgi.service.jdbc.DataSourceFactory.*;
 
 import java.io.File;
@@ -42,7 +42,7 @@ import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.Option;
 import org.ops4j.pax.exam.junit.PaxExam;
 import org.ops4j.pax.exam.spi.reactors.ExamReactorStrategy;
-import org.ops4j.pax.exam.spi.reactors.PerMethod;
+import org.ops4j.pax.exam.spi.reactors.PerClass;
 import org.ops4j.pax.exam.util.PathUtils;
 import org.osc.controller.nsc.api.SampleSdnRedirectionApi;
 import org.osc.controller.nsc.entities.InspectionHookEntity;
@@ -63,7 +63,7 @@ import org.osgi.service.transaction.control.jpa.JPAEntityManagerProviderFactory;
 import junit.framework.Assert;
 
 @RunWith(PaxExam.class)
-@ExamReactorStrategy(PerMethod.class)
+@ExamReactorStrategy(PerClass.class)
 public class OSGiIntegrationTest {
 
     private static final String TEST_DB_URL_PREFIX = "jdbc:h2:";


### PR DESCRIPTION
getting issue with unable to delete geronimo-jta_1.1_spec since its is a bootClasspathLibrary.

Changing to PerClass startegy seems to fix the problem.

```
org.ops4j.pax.exam.TestContainerException: Cannot delete C:\Users\anadendl\AppData\Local\Temp\1504909589451-0\org.apache.geronimo.specs.geronimo-jta_1.1_spec_1.1.1.jar
	at org.ops4j.pax.exam.forked.provision.PlatformImpl.download(PlatformImpl.java:165)
	at org.ops4j.pax.exam.forked.ForkedTestContainer.localize(ForkedTestContainer.java:373)
	at org.ops4j.pax.exam.forked.ForkedTestContainer.start(ForkedTestContainer.java:151)
	at org.ops4j.pax.exam.spi.reactors.AllConfinedStagedReactor.invoke(AllConfinedStagedReactor.java:79)
	at org.ops4j.pax.exam.junit.impl.ProbeRunner$2.evaluate(ProbeRunner.java:267)
	at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:325)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:78)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:57)
	at org.junit.runners.ParentRunner$3.run(ParentRunner.java:290)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:71)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:288)
	at org.junit.runners.ParentRunner.access$000(ParentRunner.java:58)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:268)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:363)
	at org.ops4j.pax.exam.junit.impl.ProbeRunner.run(ProbeRunner.java:98)
	at org.ops4j.pax.exam.junit.PaxExam.run(PaxExam.java:93)
	at org.eclipse.jdt.internal.junit4.runner.JUnit4TestReference.run(JUnit4TestReference.java:86)
	at org.eclipse.jdt.internal.junit.runner.TestExecution.run(TestExecution.java:38)
	at org.eclipse.jdt.internal.junit.runner.RemoteTestRunner.runTests(RemoteTestRunner.java:459)
	at org.eclipse.jdt.internal.junit.runner.RemoteTestRunner.runTests(RemoteTestRunner.java:678)
	at org.eclipse.jdt.internal.junit.runner.RemoteTestRunner.run(RemoteTestRunner.java:382)
	at org.eclipse.jdt.internal.junit.runner.RemoteTestRunner.main(RemoteTestRunner.java:192)


```