### PR TITLE
Register inspection port supporting updates given the existing inspection port id

### DIFF
--- a/src/main/java/org/osc/controller/nsc/entities/NetworkElementEntity.java
+++ b/src/main/java/org/osc/controller/nsc/entities/NetworkElementEntity.java
@@ -44,6 +44,9 @@ public class NetworkElementEntity implements NetworkElement {
     @Column(name = "element_id", unique = true)
     private String elementId;
 
+    @Column(name = "device_owner_id")
+    private String deviceOwnerId;
+
     // TODO : for SFC functionality
     @Transient
     private String parentId;
@@ -51,14 +54,14 @@ public class NetworkElementEntity implements NetworkElement {
     @ElementCollection(fetch = EAGER)
     @Fetch(FetchMode.SELECT)
     @CollectionTable(name = "NETWORK_ELEMENT_MACADDRESSES",
-            joinColumns = @JoinColumn(name = "network_element_fk"),
-            foreignKey = @ForeignKey(name = "FK_NETWORK_ELEMENT_MACADDRESSES_NETWORK_ELEMENT"))
+    joinColumns = @JoinColumn(name = "network_element_fk"),
+    foreignKey = @ForeignKey(name = "FK_NETWORK_ELEMENT_MACADDRESSES_NETWORK_ELEMENT"))
     private List<String> macAddresses;
 
     @ElementCollection(fetch = EAGER)
     @CollectionTable(name = "NETWORK_ELEMENT_PORTIPS",
-            joinColumns = @JoinColumn(name = "network_element_fk"),
-            foreignKey = @ForeignKey(name = "FK_NETWORK_ELEMENT_PORTIPS_NETWORK_ELEMENT"))
+    joinColumns = @JoinColumn(name = "network_element_fk"),
+    foreignKey = @ForeignKey(name = "FK_NETWORK_ELEMENT_PORTIPS_NETWORK_ELEMENT"))
     private List<String> portIPs;
 
     @OneToOne(cascade = CascadeType.ALL, orphanRemoval = false, fetch = EAGER, optional = true)

--- a/src/main/resources/META-INF/create.sql
+++ b/src/main/resources/META-INF/create.sql
@@ -4,7 +4,7 @@ create sequence if not exists hibernate_sequence start with 1 increment by 1;
 create table if not exists INSPECTION_HOOK (hook_id varchar(255) not null, inspected_port_fk varchar(255), inspection_port_fk varchar(255), tag bigint, hook_order bigint, enc_type varchar(255), failure_policy_type varchar(255), primary key (hook_id) );
 create table if not exists INSPECTION_PORT (element_id varchar(255) not null, ingress_fk varchar(255), egress_fk varchar(255), primary key (element_id) );
 
-create table if not exists NETWORK_ELEMENT (element_id varchar(255) not null, inspection_hook_fk varchar(255), primary key (element_id) );
+create table if not exists NETWORK_ELEMENT (element_id varchar(255) not null, device_owner_id varchar(255), inspection_hook_fk varchar(255), primary key (element_id) );
 
 alter table INSPECTION_HOOK add constraint if not exists FK_INSPECTION_HOOK_NETWORK_ELEMENT foreign key (inspected_port_fk) references NETWORK_ELEMENT;
 alter table NETWORK_ELEMENT add constraint if not exists FK_NETWORK_ELEMENT_INSPECTION_HOOK foreign key (inspection_hook_fk) references INSPECTION_HOOK;


### PR DESCRIPTION
Most of the code needed to register an inspection port was already in this plugin. However, for the calls to register an insp port not to fail OSC must provide the information to the plugin related to a legitimate (existing) network element. For that reason the network element returned by device owner id must be pre-populated in the database and the plugin must return this data when invoked by OSC. 
To facilitate demos with deployment specs the query for pod VNFs ports is a little lax using only the id prefix (deployment name). This is because it is not possible to predict the actual pod names generated by Kubernetes.