### PR TITLE
Adding the port group entity

### DIFF
--- a/src/main/java/org/osc/controller/nsc/api/SampleSdnControllerApi.java
+++ b/src/main/java/org/osc/controller/nsc/api/SampleSdnControllerApi.java
@@ -17,6 +17,7 @@
 package org.osc.controller.nsc.api;
 
 import static java.util.Collections.singletonMap;
+import static org.osc.controller.nsc.utils.RedirectionApiUtils.SUPPORTS_PORT_GROUP_VALUE;
 import static org.osc.sdk.controller.Constants.*;
 import static org.osgi.service.jdbc.DataSourceFactory.*;
 
@@ -43,16 +44,15 @@ import org.osgi.service.transaction.control.TransactionControl;
 import org.osgi.service.transaction.control.jpa.JPAEntityManagerProviderFactory;
 
 @Component(configurationPid = "com.intel.nsc.SdnController",
-    property = { PLUGIN_NAME + "=NSC",
-                 SUPPORT_OFFBOX_REDIRECTION + ":Boolean=false",
-                 SUPPORT_SFC + ":Boolean=false",
-                 SUPPORT_FAILURE_POLICY + ":Boolean=false",
-                 USE_PROVIDER_CREDS + ":Boolean=true",
-                 QUERY_PORT_INFO + ":Boolean=false",
-                 SUPPORT_PORT_GROUP + ":Boolean=false",
-                 SUPPORT_NEUTRON_SFC + ":Boolean=false" })
+property = { PLUGIN_NAME + "=NSC",
+        SUPPORT_OFFBOX_REDIRECTION + ":Boolean=false",
+        SUPPORT_SFC + ":Boolean=false",
+        SUPPORT_FAILURE_POLICY + ":Boolean=false",
+        USE_PROVIDER_CREDS + ":Boolean=true",
+        QUERY_PORT_INFO + ":Boolean=false",
+        SUPPORT_PORT_GROUP + SUPPORTS_PORT_GROUP_VALUE,
+        SUPPORT_NEUTRON_SFC + ":Boolean=false" })
 public class SampleSdnControllerApi implements SdnControllerApi {
-
     @Reference(target = "(osgi.local.enabled=true)")
     private TransactionControl txControl;
 

--- a/src/main/java/org/osc/controller/nsc/api/SampleSdnRedirectionApi.java
+++ b/src/main/java/org/osc/controller/nsc/api/SampleSdnRedirectionApi.java
@@ -438,6 +438,7 @@ public class SampleSdnRedirectionApi implements SdnRedirectionApi {
             throw new UnsupportedOperationException("Retrieving the network elements is only supported for SDN supporting port group.");
         }
 
+        // TODO emanoel: This method is currently not referenced by OSC.
         return null;
     }
 

--- a/src/main/java/org/osc/controller/nsc/entities/NetworkElementEntity.java
+++ b/src/main/java/org/osc/controller/nsc/entities/NetworkElementEntity.java
@@ -28,6 +28,7 @@ import javax.persistence.Entity;
 import javax.persistence.ForeignKey;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
 import javax.persistence.OneToOne;
 import javax.persistence.Table;
 
@@ -65,6 +66,10 @@ public class NetworkElementEntity implements NetworkElement {
     @OneToOne(cascade = CascadeType.ALL, orphanRemoval = false, fetch = EAGER, optional = true)
     @JoinColumn(name = "inspection_hook_fk", nullable = true, updatable = true)
     private InspectionHookEntity inspectionHook;
+
+    @ManyToOne(cascade = {CascadeType.PERSIST, CascadeType.MERGE, CascadeType.REFRESH}, fetch = EAGER, optional = true)
+    @JoinColumn(name = "port_group_fk", nullable = true, updatable = true)
+    private PortGroupEntity portGroup;
 
     public NetworkElementEntity() {
     }
@@ -116,6 +121,18 @@ public class NetworkElementEntity implements NetworkElement {
     @Override
     public String getParentId() {
         return this.parentId;
+    }
+
+    public void setParentId(String parentId) {
+        this.parentId = parentId;
+    }
+
+    public PortGroupEntity getPortGroup() {
+        return this.portGroup;
+    }
+
+    public void setPortGroup(PortGroupEntity portGroupEntity) {
+        this.portGroup = portGroupEntity;
     }
 
     @Override

--- a/src/main/java/org/osc/controller/nsc/entities/PortGroupEntity.java
+++ b/src/main/java/org/osc/controller/nsc/entities/PortGroupEntity.java
@@ -1,0 +1,90 @@
+/*******************************************************************************
+ * Copyright (c) Intel Corporation
+ * Copyright (c) 2017
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+package org.osc.controller.nsc.entities;
+
+import static javax.persistence.FetchType.EAGER;
+
+import java.util.List;
+import java.util.Set;
+
+import javax.persistence.CascadeType;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.OneToMany;
+import javax.persistence.Table;
+
+import org.hibernate.annotations.GenericGenerator;
+import org.osc.sdk.controller.element.NetworkElement;
+
+@Entity
+@Table(name = "PORT_GROUP")
+public class PortGroupEntity implements NetworkElement {
+    @Id
+    @GeneratedValue(generator = "uuid")
+    @GenericGenerator(name = "uuid", strategy = "uuid2")
+    @Column(name = "element_id", unique = true)
+    private String elementId;
+
+    @OneToMany(cascade = CascadeType.ALL, orphanRemoval = false, fetch = EAGER, mappedBy="portGroup")
+    private Set<NetworkElementEntity> virtualPorts;
+
+    @Column(name = "parent_id")
+    private String parentId;
+
+    public PortGroupEntity() {
+    }
+
+    public PortGroupEntity(String elementId, String parentId, Set<NetworkElementEntity> virtualPorts) {
+        this.elementId = elementId;
+        this.parentId = parentId;
+        this.virtualPorts = virtualPorts;
+    }
+
+    @Override
+    public String getElementId() {
+        return this.elementId;
+    }
+
+    public void setId(String elementId) {
+        this.elementId = elementId;
+    }
+
+    public void setVirtualPorts(Set<NetworkElementEntity> virtualPorts) {
+        this.virtualPorts = virtualPorts;
+    }
+
+    public Set<NetworkElementEntity> getVirtualPorts() {
+        return this.virtualPorts;
+    }
+
+    @Override
+    public String getParentId() {
+        return this.parentId;
+    }
+
+    @Override
+    public List<String> getMacAddresses() {
+        return null;
+    }
+
+    @Override
+    public List<String> getPortIPs() {
+        return null;
+    }
+}

--- a/src/main/java/org/osc/controller/nsc/utils/RedirectionApiUtils.java
+++ b/src/main/java/org/osc/controller/nsc/utils/RedirectionApiUtils.java
@@ -20,7 +20,9 @@ import static org.osc.sdk.controller.FailurePolicyType.NA;
 import static org.osc.sdk.controller.TagEncapsulationType.VLAN;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 import javax.persistence.EntityManager;
 import javax.persistence.Query;
@@ -32,6 +34,7 @@ import org.apache.log4j.Logger;
 import org.osc.controller.nsc.entities.InspectionHookEntity;
 import org.osc.controller.nsc.entities.InspectionPortEntity;
 import org.osc.controller.nsc.entities.NetworkElementEntity;
+import org.osc.controller.nsc.entities.PortGroupEntity;
 import org.osc.sdk.controller.FailurePolicyType;
 import org.osc.sdk.controller.TagEncapsulationType;
 import org.osc.sdk.controller.element.InspectionPortElement;
@@ -39,7 +42,7 @@ import org.osc.sdk.controller.element.NetworkElement;
 import org.osgi.service.transaction.control.TransactionControl;
 
 public class RedirectionApiUtils {
-
+    public final static String SUPPORTS_PORT_GROUP_VALUE = ":Boolean=false";
     private static final Logger LOG = Logger.getLogger(RedirectionApiUtils.class);
 
     private TransactionControl txControl;
@@ -50,22 +53,17 @@ public class RedirectionApiUtils {
         this.txControl = txControl;
     }
 
-    public NetworkElementEntity makeNetworkElementEntity(NetworkElement networkElement) {
-        NetworkElementEntity retVal = new NetworkElementEntity();
-
-        retVal.setElementId(networkElement.getElementId());
-        retVal.setMacAddresses(networkElement.getMacAddresses());
-        retVal.setPortIPs(networkElement.getPortIPs());
-
-        return retVal;
-    }
-
     public InspectionPortEntity makeInspectionPortEntity(InspectionPortElement inspectionPortElement) {
         throwExceptionIfNullElement(inspectionPortElement);
 
         NetworkElement ingress = inspectionPortElement.getIngressPort();
         throwExceptionIfNullElement(ingress, "Null ingress element.");
-        NetworkElementEntity ingressEntity = makeNetworkElementEntity(ingress);
+        NetworkElementEntity ingressEntity = null;
+        if (ingress.getElementId() != null) {
+            ingressEntity = findNetworkElementEntityByElementId(ingress.getElementId());
+        }
+
+        ingressEntity = ingressEntity == null ? makeNetworkElementEntity(ingress) : ingressEntity;
 
         NetworkElement egress = inspectionPortElement.getEgressPort();
         NetworkElementEntity egressEntity = null;
@@ -74,10 +72,44 @@ public class RedirectionApiUtils {
         if (ingressEntity != null && ingressEntity.getElementId().equals(egress.getElementId())) {
             egressEntity = ingressEntity;
         } else {
-            egressEntity = makeNetworkElementEntity(egress);
+            if (egress.getElementId() != null) {
+                egressEntity = findNetworkElementEntityByElementId(egress.getElementId());
+            }
+
+            egressEntity = egressEntity == null ? makeNetworkElementEntity(egress) : egressEntity;
         }
 
         return new InspectionPortEntity(inspectionPortElement.getElementId(), ingressEntity, egressEntity);
+    }
+
+    public PortGroupEntity makePortGroupEntity(List<NetworkElement> inspectedPorts) {
+        // Using the same parent id as the inspected ports, all the parent ids of the inspected ports
+        // are expected to be the same.
+        PortGroupEntity portGroupEntity = new PortGroupEntity(null, inspectedPorts.get(0).getParentId(), null);
+        Set<NetworkElementEntity> inspectedPortEntities = networkElementsToEntities(inspectedPorts);
+
+        inspectedPortEntities.forEach(inspectedPortEntity -> inspectedPortEntity.setPortGroup(portGroupEntity));
+        portGroupEntity.setVirtualPorts(inspectedPortEntities);
+
+        return portGroupEntity;
+    }
+
+    public Set<NetworkElementEntity> networkElementsToEntities(List<NetworkElement> inspectedPorts) {
+        throwExceptionIfNullInspectedPorts(inspectedPorts);
+        Set<NetworkElementEntity> inspectedPortEntities = new HashSet<>();
+
+        for (NetworkElement inspectedPort : inspectedPorts) {
+            NetworkElementEntity inspectedPortEntity = null;
+
+            if (inspectedPort.getElementId() != null) {
+                inspectedPortEntity = findNetworkElementEntityByElementId(inspectedPort.getElementId());
+            }
+
+            inspectedPortEntities.add(inspectedPortEntity == null ?
+                    makeNetworkElementEntity(inspectedPort) : inspectedPortEntity);
+        }
+
+        return inspectedPortEntities;
     }
 
     public InspectionHookEntity makeInspectionHookEntity(NetworkElement inspectedPort,
@@ -107,6 +139,12 @@ public class RedirectionApiUtils {
         return retVal;
     }
 
+    public NetworkElementEntity findNetworkElementEntityByElementId(String elementId) {
+        return this.txControl.required(() -> {
+            return txNetworkElementEntityByElementId(elementId);
+        });
+    }
+
     public NetworkElementEntity txNetworkElementEntityByElementId(String elementId) {
         CriteriaBuilder cb = this.em.getCriteriaBuilder();
 
@@ -120,6 +158,27 @@ public class RedirectionApiUtils {
             LOG.error(String.format("Finding Network Element %s ", elementId), e);
             return null;
         }
+    }
+
+    public PortGroupEntity txPortGroupEntity(String elementId, String parentId) {
+        CriteriaBuilder cb = this.em.getCriteriaBuilder();
+
+        CriteriaQuery<PortGroupEntity> q = cb.createQuery(PortGroupEntity.class);
+        Root<PortGroupEntity> r = q.from(PortGroupEntity.class);
+        q.where(cb.equal(r.get("elementId"), elementId), cb.equal(r.get("parentId"), parentId));
+
+        try {
+            return this.em.createQuery(q).getSingleResult();
+        } catch (Exception e) {
+            LOG.error(String.format("Finding port group entity id '%s' and parentId '%s' ", elementId, parentId), e);
+            return null;
+        }
+    }
+
+    public PortGroupEntity findPortGroupEntity(String elementId, String parentId) {
+        return this.txControl.required(() -> {
+            return txPortGroupEntity(elementId, parentId);
+        });
     }
 
     public NetworkElementEntity findNetworkElementEntityByDeviceOwnerId(String deviceOwnerId) {
@@ -157,37 +216,6 @@ public class RedirectionApiUtils {
 
     public InspectionPortEntity findInspPortByNetworkElements(NetworkElement ingress, NetworkElement egress) {
         return this.txControl.required(() -> txInspPortByNetworkElements(ingress, egress));
-    }
-
-    private InspectionPortEntity txInspPortByNetworkElements(NetworkElement ingress, NetworkElement egress) {
-        String ingressId = ingress != null ? ingress.getElementId() : null;
-        String egressId = ingress != null ? egress.getElementId() : null;
-
-        CriteriaBuilder cb = this.em.getCriteriaBuilder();
-        CriteriaQuery<InspectionPortEntity> criteria = cb.createQuery(InspectionPortEntity.class);
-        Root<InspectionPortEntity> root = criteria.from(InspectionPortEntity.class);
-        criteria.select(root).where(cb.and(
-                cb.equal(root.join("ingressPort").get("elementId"), ingressId),
-                cb.equal(root.join("egressPort").get("elementId"), egressId)));
-        Query q= this.em.createQuery(criteria);
-
-        try {
-            @SuppressWarnings("unchecked")
-            List<InspectionPortEntity> ports = q.getResultList();
-            if (ports == null || ports.size() == 0) {
-                LOG.warn(String.format("No Inspection Ports by ingress %s and egress %s", ingressId, egressId));
-                return null;
-            } else if (ports.size() > 1) {
-                LOG.warn(String.format("Multiple results! Inspection Ports by ingress %s and egress %s", ingressId,
-                        egressId));
-            }
-            return ports.get(0);
-
-        } catch (Exception e) {
-            LOG.error(String.format("Finding Inspection Ports by ingress %s and egress %s", ingress.getElementId(),
-                    egress.getElementId()), e);
-            return null;
-        }
     }
 
     public InspectionHookEntity findInspHookByInspectedAndPort(NetworkElement inspected,
@@ -254,6 +282,79 @@ public class RedirectionApiUtils {
         });
     }
 
+    public List<InspectionHookEntity> txInspectionHookEntitiesByInspected(String inspectedId) {
+
+        CriteriaBuilder cb = this.em.getCriteriaBuilder();
+        CriteriaQuery<InspectionHookEntity> criteria = cb.createQuery(InspectionHookEntity.class);
+        Root<InspectionHookEntity> root = criteria.from(InspectionHookEntity.class);
+
+        criteria.select(root).where(cb.equal(root.join("inspectedPort").get("elementId"), inspectedId));
+
+        Query q= this.em.createQuery(criteria);
+
+        @SuppressWarnings("unchecked")
+        List<InspectionHookEntity> results = q.getResultList();
+
+        return results;
+    }
+
+    public void throwExceptionIfNullEntity(InspectionPortEntity inspectionPortTmp, InspectionPortElement inspectionPort)
+            throws IllegalArgumentException {
+        if (inspectionPortTmp == null) {
+            String msg = String.format(
+                    "Cannot find inspection port for inspection hook " + "id: %s; ingress: %s; egress: %s\n",
+                    inspectionPort.getElementId(),
+                    "" + inspectionPort.getIngressPort(),
+                    "" + inspectionPort.getEgressPort());
+            LOG.error(msg);
+            throw new IllegalArgumentException(msg);
+        }
+    }
+
+    public void throwExceptionIfNullElement(NetworkElement networkElement, String msg) {
+        if (networkElement == null) {
+            msg = (msg != null ? msg : "null passed for Network Element argument!");
+            LOG.error(msg);
+            throw new IllegalArgumentException(msg);
+        }
+    }
+
+    public static boolean supportsPortGroup() {
+        String supportsPortGroupValue = SUPPORTS_PORT_GROUP_VALUE.split("=")[1];
+        return Boolean.parseBoolean(supportsPortGroupValue);
+    }
+
+    private InspectionPortEntity txInspPortByNetworkElements(NetworkElement ingress, NetworkElement egress) {
+        String ingressId = ingress != null ? ingress.getElementId() : null;
+        String egressId = ingress != null ? egress.getElementId() : null;
+
+        CriteriaBuilder cb = this.em.getCriteriaBuilder();
+        CriteriaQuery<InspectionPortEntity> criteria = cb.createQuery(InspectionPortEntity.class);
+        Root<InspectionPortEntity> root = criteria.from(InspectionPortEntity.class);
+        criteria.select(root).where(cb.and(
+                cb.equal(root.join("ingressPort").get("elementId"), ingressId),
+                cb.equal(root.join("egressPort").get("elementId"), egressId)));
+        Query q= this.em.createQuery(criteria);
+
+        try {
+            @SuppressWarnings("unchecked")
+            List<InspectionPortEntity> ports = q.getResultList();
+            if (ports == null || ports.size() == 0) {
+                LOG.warn(String.format("No Inspection Ports by ingress %s and egress %s", ingressId, egressId));
+                return null;
+            } else if (ports.size() > 1) {
+                LOG.warn(String.format("Multiple results! Inspection Ports by ingress %s and egress %s", ingressId,
+                        egressId));
+            }
+            return ports.get(0);
+
+        } catch (Exception e) {
+            LOG.error(String.format("Finding Inspection Ports by ingress %s and egress %s", ingress.getElementId(),
+                    egress.getElementId()), e);
+            return null;
+        }
+    }
+
     private InspectionHookEntity txInspHookByInspectedAndPort(NetworkElement inspected, InspectionPortElement element) {
         // Paranoid
         NetworkElement ingress = element != null ? element.getIngressPort() : null;
@@ -291,48 +392,28 @@ public class RedirectionApiUtils {
         }
     }
 
-    public List<InspectionHookEntity> txInspectionHookEntitiesByInspected(String inspectedId) {
-
-        CriteriaBuilder cb = this.em.getCriteriaBuilder();
-        CriteriaQuery<InspectionHookEntity> criteria = cb.createQuery(InspectionHookEntity.class);
-        Root<InspectionHookEntity> root = criteria.from(InspectionHookEntity.class);
-
-        criteria.select(root).where(cb.equal(root.join("inspectedPort").get("elementId"), inspectedId));
-
-        Query q= this.em.createQuery(criteria);
-
-        @SuppressWarnings("unchecked")
-        List<InspectionHookEntity> results = q.getResultList();
-
-        return results;
-    }
-
-    public void throwExceptionIfNullEntity(InspectionPortEntity inspectionPortTmp, InspectionPortElement inspectionPort)
-            throws IllegalArgumentException {
-        if (inspectionPortTmp == null) {
-            String msg = String.format(
-                    "Cannot find inspection port for inspection hook " + "id: %s; ingress: %s; egress: %s\n",
-                    inspectionPort.getElementId(),
-                    "" + inspectionPort.getIngressPort(),
-                    "" + inspectionPort.getEgressPort());
-            LOG.error(msg);
-            throw new IllegalArgumentException(msg);
-        }
-    }
-
-    private void throwExceptionIfNullElement(NetworkElement networkElement, String msg) {
-        if (networkElement == null) {
-            msg = (msg != null ? msg : "null passed for Network Element argument!");
-            LOG.error(msg);
-            throw new IllegalArgumentException(msg);
-        }
-    }
-
     private void throwExceptionIfNullElement(InspectionPortElement networkElement) {
         if (networkElement == null) {
             String msg = "null passed for Inspection Port argument!";
             LOG.error(msg);
             throw new IllegalArgumentException(msg);
         }
+    }
+
+    private void throwExceptionIfNullInspectedPorts(List<NetworkElement> inspectedPorts) {
+        if (inspectedPorts == null) {
+            String msg = "null passed for inspected ports argument!";
+            throw new IllegalArgumentException(msg);
+        }
+    }
+
+    private static NetworkElementEntity makeNetworkElementEntity(NetworkElement networkElement) {
+        NetworkElementEntity retVal = new NetworkElementEntity();
+
+        retVal.setElementId(networkElement.getElementId());
+        retVal.setMacAddresses(networkElement.getMacAddresses());
+        retVal.setPortIPs(networkElement.getPortIPs());
+
+        return retVal;
     }
 }

--- a/src/main/resources/META-INF/create.sql
+++ b/src/main/resources/META-INF/create.sql
@@ -4,7 +4,9 @@ create sequence if not exists hibernate_sequence start with 1 increment by 1;
 create table if not exists INSPECTION_HOOK (hook_id varchar(255) not null, inspected_port_fk varchar(255), inspection_port_fk varchar(255), tag bigint, hook_order bigint, enc_type varchar(255), failure_policy_type varchar(255), primary key (hook_id) );
 create table if not exists INSPECTION_PORT (element_id varchar(255) not null, ingress_fk varchar(255), egress_fk varchar(255), primary key (element_id) );
 
-create table if not exists NETWORK_ELEMENT (element_id varchar(255) not null, device_owner_id varchar(255), parent_id varchar(255), inspection_hook_fk varchar(255), primary key (element_id) );
+create table if not exists NETWORK_ELEMENT (element_id varchar(255) not null, device_owner_id varchar(255), parent_id varchar(255), inspection_hook_fk varchar(255), port_group_fk varchar(255), primary key (element_id) );
+
+create table if not exists PORT_GROUP (element_id varchar(255) not null, parent_id varchar(255), primary key (element_id) );
 
 alter table INSPECTION_HOOK add constraint if not exists FK_INSPECTION_HOOK_NETWORK_ELEMENT foreign key (inspected_port_fk) references NETWORK_ELEMENT;
 alter table NETWORK_ELEMENT add constraint if not exists FK_NETWORK_ELEMENT_INSPECTION_HOOK foreign key (inspection_hook_fk) references INSPECTION_HOOK;
@@ -13,6 +15,8 @@ alter table INSPECTION_PORT add constraint if not exists FK_INSPECTION_PORT_NETW
 alter table INSPECTION_PORT add constraint if not exists FK_INSPECTION_PORT_NETWORK_ELEMENT_EGR foreign key (egress_fk) references NETWORK_ELEMENT;
 
 alter table INSPECTION_HOOK add constraint if not exists FK_INSPECTION_HOOK_INSPECTION_PORT foreign key (inspection_port_fk) references INSPECTION_PORT;
+
+alter table NETWORK_ELEMENT add constraint if not exists FK_NETWORK_ELEMENT_PORT_GROUP foreign key (port_group_fk) references PORT_GROUP;
 
 create table if not exists NETWORK_ELEMENT_PORTIPS (network_element_fk varchar(255), PORTIPS varchar(255));
 create table if not exists NETWORK_ELEMENT_MACADDRESSES (network_element_fk varchar(255), MACADDRESSES varchar(255));


### PR DESCRIPTION
This PR add the port group entity to the plugin DB and implements the create, update and delete methods for this entity used by OSC when an SDN controller supports grouping virtual inspected ports.